### PR TITLE
bugfix/removing carriage return

### DIFF
--- a/include/redis-cpp/resp/deserialization.h
+++ b/include/redis-cpp/resp/deserialization.h
@@ -69,6 +69,7 @@ public:
     simple_string(std::istream &stream)
     {
         std::getline(stream, value_);
+        value_.pop_back(); // removing '\r' from string
     }
 
     [[nodiscard]]
@@ -87,6 +88,7 @@ public:
     error_message(std::istream &stream)
     {
         std::getline(stream, value_);
+        value_.pop_back(); // removing '\r' from string
     }
 
     [[nodiscard]]


### PR DESCRIPTION
While creating a simple_string or an error_message from stream the getline function splits at '\n' while the '\r' still remains. This bugfix will remove the '\r' at the end of simple_string or error_message.