### PR TITLE
Always mark `get_mark` as `inline`

### DIFF
--- a/include/redis-cpp/resp/deserialization.h
+++ b/include/redis-cpp/resp/deserialization.h
@@ -30,7 +30,7 @@ inline namespace resp
 namespace deserialization
 {
 [[nodiscard]]
-REDISCPP_INLINE
+inline
 auto get_mark(std::istream &stream)
 {
     switch (stream.get())


### PR DESCRIPTION
I am using your library in a project where I want to use it in multiple places. Unfortunately, if I include the headers of the library in different cpp files, I get the error `multiple definition of 'rediscpp::resp::deserialization::get_mark(std::istream&)'`. Looking at this function, it is a function definition in the header itself, which my LSP also warns me about (it's https://clang.llvm.org/extra/clang-tidy/checks/misc/definitions-in-headers.html). Applying my change fixes the compilation error.You might want to get rid of `REDISCPP_INLINE` altogether now, because there are no other uses as far as I can tell (I can also include this in this PR if you want).

(Related: #13)