### PR TITLE
bugfix/make an empty binary_data string parse correctly

### DIFF
--- a/include/redis-cpp/resp/deserialization.h
+++ b/include/redis-cpp/resp/deserialization.h
@@ -131,10 +131,11 @@ public:
             is_null_ = true;
             return;
         }
-        if (length < 1)
-            return;
-        data_.resize(static_cast<typename buffer_type::size_type>(length));
-        stream.read(&data_[0], length);
+        if (length > 0)
+        {
+            data_.resize(static_cast<typename buffer_type::size_type>(length));
+            stream.read(&data_[0], length);
+        }
         std::getline(stream, string);
     }
 


### PR DESCRIPTION
fixes #32

> ...if redis returns an empty bulk string there will be a `\r\n` left on the stream after the binary data constructor. An empty bulk string is represented as `$0\r\n\r\n` according to [the redis documentation](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings) but the constructor returns prior to popping those last two characters.
> 
> ## To reproduce
> Launch a new redis instance however you see fit.
> 
> Create a `.cpp` file containing the following:
> 
> ```c++
> #include <redis-cpp/stream.h>
> #include <redis-cpp/execute.h>
> int main(int argc, char** argv)
> {
>     auto stream = rediscpp::make_stream(argv[1], argv[2]);
>     rediscpp::execute(*stream, "config", "get", "*");
> }
> ```
> 
> Compile it and run it with the first and second arguments being the hostname and port of your redis instance. At some point during the parsing of the response you are nearly guaranteed it will throw a `[rediscpp::resp::deserialization::get_mark]` error when it runs into a `\r` where it expects the next value type marker.
