### PR TITLE
WIP: RESP3

### DIFF
--- a/include/redis-cpp/resp/deserialization.h
+++ b/include/redis-cpp/resp/deserialization.h
@@ -18,10 +18,17 @@
 #include <string_view>
 #include <variant>
 #include <vector>
+#include <map>
+#include <set>
+#include <optional>
+
+// BOOST
+#include <boost/mp11.hpp>
 
 // REDIS-CPP
 #include <redis-cpp/detail/config.h>
 #include <redis-cpp/resp/detail/marker.h>
+#include <redis-cpp/resp/detail/value_ptr.h>
 
 namespace rediscpp
 {
@@ -30,20 +37,28 @@ inline namespace resp
 namespace deserialization
 {
 [[nodiscard]]
-inline auto get_mark(std::istream &stream)
+inline char get_mark(std::istream &stream)
 {
-    switch (stream.get())
+    auto mark = stream.get();
+    switch (mark)
     {
     case detail::marker::simple_string :
-        return detail::marker::simple_string;
     case detail::marker::error_message :
-        return detail::marker::error_message;
     case detail::marker::integer :
-        return detail::marker::integer;
     case detail::marker::bulk_string :
-        return detail::marker::bulk_string;
     case detail::marker::array :
-        return detail::marker::array;
+    case detail::marker::null :
+    case detail::marker::boolean :
+    case detail::marker::double_float :
+    case detail::marker::big_number :
+    case detail::marker::bulk_error :
+    case detail::marker::verbatim_string :
+    case detail::marker::map :
+    case detail::marker::attributes_alt :
+    case detail::marker::attributes :
+    case detail::marker::set :
+    case detail::marker::push :
+        return char(mark);
     default:
         break;
     }
@@ -60,9 +75,109 @@ T get(std::istream &stream)
     return {stream};
 }
 
-class simple_string final
+
+class mapped_data final
 {
 public:
+    struct items_type;
+
+    mapped_data(std::istream &stream);
+    mapped_data(const mapped_data &other) noexcept;
+    mapped_data(mapped_data &&other) noexcept;
+    mapped_data& operator=(const mapped_data &other) noexcept;
+    mapped_data& operator=(mapped_data &&other) noexcept;
+    ~mapped_data() noexcept;
+
+    [[nodiscard]]
+    std::size_t size() const noexcept;
+
+    [[nodiscard]]
+    items_type const& get() const noexcept;
+
+private:
+    [[nodiscard]]
+    items_type* get_map() noexcept
+    {
+        return reinterpret_cast<items_type*>(map_buffer);
+    }
+    [[nodiscard]]
+    items_type const* get_map() const noexcept
+    {
+        return reinterpret_cast<const items_type*>(map_buffer);
+    }
+
+    alignas(std::map<int, int, std::less<>>) std::byte map_buffer[sizeof(std::map<int, int, std::less<>>)];
+};
+
+class attributes final
+{
+public:
+    static constexpr auto marker = detail::marker::attributes;
+    using items_type = mapped_data::items_type;
+
+    attributes(std::istream &stream)
+        : items_(stream)
+    {}
+
+    [[nodiscard]]
+    std::size_t size() const noexcept { return items_.size(); }
+
+    [[nodiscard]]
+    items_type const& get() const noexcept { return items_.get(); }
+private:
+    mapped_data items_;
+};
+
+template<class T>
+auto operator<(const T& rhs, const T& lhs) -> decltype(rhs.get() < lhs.get())
+{
+    return rhs.get() < lhs.get();
+}
+
+struct set_attributes_fn
+{
+    template<class T>
+    void operator()(T& value, detail::value_ptr<attributes> attrs) const
+    {
+        value.attributes_ = std::move(attrs);
+    }
+
+    template<class... Ts>
+    void operator()(std::variant<Ts...>& variant, detail::value_ptr<attributes> attrs) const
+    {
+        std::visit([&](auto& value){(*this)(value, std::move(attrs));}, variant);
+    }
+};
+
+constexpr set_attributes_fn set_attributes{};
+
+class attributed
+{
+public:
+    bool has_attributes() const
+    {
+        return bool(attributes_);
+    }
+    
+    attributes& get_attributes() const
+    {
+        if(has_attributes())
+        {
+            return *attributes_;
+        }
+        throw std::bad_optional_access();
+    }
+
+    friend struct set_attributes_fn;
+
+protected:
+    detail::value_ptr<attributes> attributes_;
+};
+
+class simple_string final: private attributed
+{
+public:
+    static constexpr auto marker = detail::marker::simple_string;
     simple_string(std::istream &stream)
     {
         std::getline(stream, value_);
@@ -75,13 +190,18 @@ public:
         return value_;
     }
 
+    using attributed::has_attributes;
+    using attributed::get_attributes;
+    friend struct set_attributes_fn;
+
 private:
     std::string value_;
 };
 
-class error_message final
+class error_message final: private attributed
 {
 public:
+    static constexpr auto marker = detail::marker::error_message;
     error_message(std::istream &stream)
     {
         std::getline(stream, value_);
@@ -94,13 +214,18 @@ public:
         return value_;
     }
 
+    using attributed::has_attributes;
+    using attributed::get_attributes;
+    friend struct set_attributes_fn;
+
 private:
     std::string value_;
 };
 
-class integer final
+class integer final: private attributed
 {
 public:
+    static constexpr auto marker = detail::marker::integer;
     integer(std::istream &stream)
     {
         std::string string;
@@ -113,6 +238,10 @@ public:
     {
         return value_;
     }
+
+    using attributed::has_attributes;
+    using attributed::get_attributes;
+    friend struct set_attributes_fn;
 
 private:
     std::int64_t value_;
@@ -169,9 +298,10 @@ private:
     buffer_type data_;
 };
 
-class bulk_string final
+class bulk_string final: private attributed
 {
 public:
+    static constexpr auto marker = detail::marker::bulk_string;
     bulk_string(std::istream &stream)
         : data_{stream}
     {
@@ -189,72 +319,325 @@ public:
         return data_.get();
     }
 
+    using attributed::has_attributes;
+    using attributed::get_attributes;
+    friend struct set_attributes_fn;
+
 private:
     binary_data data_;
 };
 
-class null final
+class null final: private attributed
 {
 public:
+    static constexpr auto marker = detail::marker::null;
+    null(std::istream &stream)
+    {
+        std::string string;
+        std::getline(stream, string);
+    }
+
     void get() const noexcept
     {
     }
+
+    static constexpr bool is_null() { return true; }
+
+    using attributed::has_attributes;
+    using attributed::get_attributes;
+    friend struct set_attributes_fn;
 };
 
-class array final
+bool operator<(const null&, const null&)
+{
+    return false;
+}
+
+class boolean final: private attributed
 {
 public:
+    static constexpr auto marker = detail::marker::boolean;
+    boolean(std::istream &stream)
+    {
+        std::string string;
+        std::getline(stream, string);
+        switch (string.front())
+        {
+        case 't':
+            value_ = true;
+            break;
+        case 'f':
+            value_ = false;
+            break;
+        default:
+            throw std::invalid_argument{
+                    "[rediscpp::resp::deserialization::boolean] "
+                    "Bad input format. Unsupported boolian value."
+                };
+        }
+    }
+
+    [[nodiscard]]
+    bool get() const noexcept
+    {
+        return value_;
+    }
+
+    using attributed::has_attributes;
+    using attributed::get_attributes;
+    friend struct set_attributes_fn;
+
+private:
+    bool value_;
+};
+
+class double_float final: private attributed
+{
+public:
+    static constexpr auto marker = detail::marker::double_float;
+    double_float(std::istream &stream)
+    {
+        std::string string;
+        std::getline(stream, string);
+        value_ = std::stod(string);
+    }
+
+    [[nodiscard]]
+    bool get() const noexcept
+    {
+        return value_;
+    }
+
+    using attributed::has_attributes;
+    using attributed::get_attributes;
+    friend struct set_attributes_fn;
+
+private:
+    double value_;
+};
+
+class big_number final: private attributed
+{
+public:
+    static constexpr auto marker = detail::marker::big_number;
+    big_number(std::istream &stream)
+    {
+        std::getline(stream, value_);
+        value_.pop_back(); // removing '\r' from string
+    }
+
+    [[nodiscard]]
+    std::string_view get() const noexcept
+    {
+        return value_;
+    }
+
+    using attributed::has_attributes;
+    using attributed::get_attributes;
+    friend struct set_attributes_fn;
+
+private:
+    std::string value_;
+};
+
+class bulk_error final: private attributed
+{
+public:
+    static constexpr auto marker = detail::marker::bulk_error;
+    bulk_error(std::istream &stream)
+        : data_{stream}
+    {
+    }
+
+    [[nodiscard]]
+    std::string_view get() const noexcept
+    {
+        return data_.get();
+    }
+
+    using attributed::has_attributes;
+    using attributed::get_attributes;
+    friend struct set_attributes_fn;
+
+private:
+    binary_data data_;
+};
+
+class verbatim_string final: private attributed
+{
+public:
+    static constexpr auto marker = detail::marker::verbatim_string;
+    constexpr static size_t encoding_length = 3;
+
+    verbatim_string(std::istream &stream)
+    {
+        std::string string;
+        std::getline(stream, string);
+        auto const length = std::stoll(string);
+        data_.resize(static_cast<typename buffer_type::size_type>(length) + encoding_length);
+        stream.read(&data_[0], encoding_length);
+        stream.get();
+        stream.read(&data_[encoding_length], length);
+        std::getline(stream, string);
+    }
+
+    [[nodiscard]]
+    std::string_view get() const noexcept
+    {
+        return {data(), size()};
+    }
+    
+    [[nodiscard]]
+    std::string_view get_encoding() const noexcept
+    {
+        return {std::data(data_), encoding_length};
+    }
+
+    [[nodiscard]]
+    std::size_t size() const noexcept
+    {
+        return std::size(data_) - encoding_length;
+    }
+
+    [[nodiscard]]
+    char const* data() const noexcept
+    {
+        return std::data(data_) + encoding_length;
+    }
+
+    using attributed::has_attributes;
+    using attributed::get_attributes;
+    friend struct set_attributes_fn;
+
+private:
+    using buffer_type = std::vector<char>;
+    buffer_type data_;
+};
+
+class map final: private attributed
+{
+public:
+    static constexpr auto marker = detail::marker::map;
+    using items_type = mapped_data::items_type;
+
+    map(std::istream &stream)
+        : items_(stream)
+    {}
+
+    [[nodiscard]]
+    std::size_t size() const noexcept { return items_.size(); }
+
+    [[nodiscard]]
+    items_type const& get() const noexcept { return items_.get(); }
+
+    using attributed::has_attributes;
+    using attributed::get_attributes;
+    friend struct set_attributes_fn;
+
+private:
+    mapped_data items_;
+};
+
+class set final: private attributed
+{
+public:
+    static constexpr auto marker = detail::marker::set;
+    struct items_type;
+
+    set(std::istream &stream);
+    set(const set &other) noexcept;
+    set(set &&other) noexcept;
+    set& operator=(const set &other) noexcept;
+    set& operator=(set &&other) noexcept;
+    ~set() noexcept;
+
+    [[nodiscard]]
+    std::size_t size() const noexcept;
+
+    [[nodiscard]]
+    items_type const& get() const noexcept;
+
+    using attributed::has_attributes;
+    using attributed::get_attributes;
+    friend struct set_attributes_fn;
+
+private:
+    [[nodiscard]]
+    items_type* get_set() noexcept
+    {
+        return reinterpret_cast<items_type*>(set_buffer);
+    }
+    [[nodiscard]]
+    items_type const* get_set() const noexcept
+    {
+        return reinterpret_cast<const items_type*>(set_buffer);
+    }
+
+    alignas(std::set<int, std::less<>>) std::byte set_buffer[sizeof(std::set<int, std::less<>>)];
+};
+
+class push final: private attributed
+{
+public:
+    static constexpr auto marker = detail::marker::push;
+    struct items_type;
+
+    push(std::istream &stream);
+    push(const push &other) noexcept;
+    push(push &&other) noexcept;
+    push& operator=(const push &other) noexcept;
+    push& operator=(push &&other) noexcept;
+    ~push() noexcept;
+
+    [[nodiscard]]
+    std::size_t size() const noexcept;
+
+    [[nodiscard]]
+    items_type const& get() const noexcept;
+
+    using attributed::has_attributes;
+    using attributed::get_attributes;
+    friend struct set_attributes_fn;
+
+private:
+    [[nodiscard]]
+    items_type* get_items() noexcept
+    {
+        return reinterpret_cast<items_type*>(vector_buffer);
+    }
+    [[nodiscard]]
+    items_type const* get_items() const noexcept
+    {
+        return reinterpret_cast<const items_type*>(vector_buffer);
+    }
+
+    alignas(std::vector<int>) std::byte vector_buffer[sizeof(std::vector<int>)];
+};
+
+class array final: private attributed
+{
+public:
+    static constexpr auto marker = detail::marker::array;
     using item_type = std::variant<
             simple_string,
             error_message,
             integer,
             bulk_string,
             array,
-            null
+            null,
+            boolean,
+            double_float,
+            big_number,
+            bulk_error,
+            verbatim_string,
+            map,
+            set,
+            push
         >;
 
     using items_type = std::vector<item_type>;
 
-    array(std::istream &stream)
-    {
-        std::string string;
-        std::getline(stream, string);
-        auto count = std::stoll(string);
-        if (count < 0)
-        {
-            is_null_ = true;
-            return;
-        }
-        if (count < 1)
-            return;
-        items_.reserve(static_cast<typename items_type::size_type>(count));
-        while (count--)
-        {
-            switch (get_mark(stream))
-            {
-            case detail::marker::simple_string :
-                items_.emplace_back(simple_string{stream});
-                break;
-            case detail::marker::error_message :
-                items_.emplace_back(error_message{stream});
-                break;
-            case detail::marker::integer :
-                items_.emplace_back(integer{stream});
-                break;
-            case detail::marker::bulk_string :
-                items_.emplace_back(bulk_string{stream});
-                break;
-            case detail::marker::array :
-                items_.emplace_back(array{stream});
-                break;
-            default:
-                throw std::invalid_argument{
-                        "[rediscpp::resp::deserialization::array] "
-                        "Bad input format. Unsupported value type."
-                    };
-            }
-        }
-    }
+    array(std::istream &stream);
 
     [[nodiscard]]
     bool is_null() const noexcept
@@ -274,10 +657,273 @@ public:
         return items_;
     }
 
+    using attributed::has_attributes;
+    using attributed::get_attributes;
+    friend struct set_attributes_fn;
+
 private:
     bool is_null_ = false;
     items_type items_;
 };
+
+constexpr char get_marker(size_t index)
+{
+    using namespace boost::mp11;
+    return mp_with_index<mp_size<array::item_type>>(index, [](auto idx)
+    {
+        using idx_t = decltype(idx);
+        return std::variant_alternative_t<idx_t::value, array::item_type>::marker;
+    });
+}
+
+constexpr char get_marker(const array::item_type& item)
+{
+    return get_marker(item.index());
+}
+
+array::item_type parse_item(std::istream& stream)
+{
+    switch (get_mark(stream))
+    {
+    case detail::marker::simple_string :
+        return simple_string{stream};
+    case detail::marker::error_message :
+        return error_message{stream};
+    case detail::marker::integer :
+        return integer{stream};
+    case detail::marker::bulk_string :
+        return bulk_string{stream};
+    case detail::marker::array :
+        return array{stream};
+    case detail::marker::null :
+        return null{stream};
+    case detail::marker::boolean :
+        return boolean{stream};
+    case detail::marker::double_float :
+        return double_float{stream};
+    case detail::marker::big_number :
+        return big_number{stream};
+    case detail::marker::bulk_error :
+        return bulk_error{stream};
+    case detail::marker::verbatim_string :
+        return verbatim_string{stream};
+    case detail::marker::map :
+        return map{stream};
+    case detail::marker::attributes_alt :
+    case detail::marker::attributes :
+    {
+        auto attrs = detail::make_value_ptr<attributes>(stream);
+        auto value = parse_item(stream);
+        set_attributes(value, std::move(attrs));
+        return std::move(value);
+    }
+    case detail::marker::set :
+        return set{stream};
+    case detail::marker::push :
+        return push{stream};
+    default:
+        break;
+    }
+    
+    throw std::invalid_argument{
+            "[rediscpp::resp::deserialization::parse_item] "
+            "Bad input format. Unsupported value type."
+        };
+}
+
+array::array(std::istream &stream)
+{
+    std::string string;
+    std::getline(stream, string);
+    auto count = std::stoll(string);
+    if (count < 0)
+    {
+        is_null_ = true;
+        return;
+    }
+    if (count < 1)
+        return;
+    items_.reserve(static_cast<typename items_type::size_type>(count));
+    while (count--)
+    {
+        items_.emplace_back(deserialization::parse_item(stream));
+    }
+}
+
+struct mapped_data::items_type: std::map<array::item_type, array::item_type, std::less<>>
+{};
+
+mapped_data::mapped_data(std::istream &stream)
+{
+    new(get_map()) items_type{};
+    auto& items_ = *get_map();
+
+    std::string string;
+    std::getline(stream, string);
+    auto count = std::stoll(string);
+
+    while (count--)
+    {
+        auto key = parse_item(stream);
+        items_.emplace(std::move(key), parse_item(stream));
+    }
+}
+
+mapped_data::mapped_data(const mapped_data &other) noexcept
+{
+    new(get_map()) items_type{*other.get_map()};
+}
+
+mapped_data::mapped_data(mapped_data &&other) noexcept
+{
+    new(get_map()) items_type{std::move(*other.get_map())};
+}
+
+mapped_data& mapped_data::operator=(const mapped_data &other) noexcept
+{
+    *get_map() = *other.get_map();
+    return *this;
+}
+
+mapped_data& mapped_data::operator=(mapped_data &&other) noexcept
+{
+    *get_map() = std::move(*other.get_map());
+    return *this;
+}
+
+mapped_data::~mapped_data() noexcept
+{
+    get_map()->~map();
+}
+
+[[nodiscard]]
+std::size_t mapped_data::size() const noexcept
+{
+    return std::size(get());
+}
+
+[[nodiscard]]
+auto mapped_data::get() const noexcept -> items_type const&
+{
+    return *get_map();
+}
+
+struct set::items_type: std::set<array::item_type, std::less<>>
+{};
+
+set::set(std::istream &stream)
+{
+    new(get_set()) items_type{};
+    auto& items_ = *get_set();
+
+    std::string string;
+    std::getline(stream, string);
+    auto count = std::stoll(string);
+
+    while (count--)
+    {
+        items_.emplace(parse_item(stream));
+    }
+}
+
+set::set(const set &other) noexcept
+{
+    new(get_set()) items_type{*other.get_set()};
+}
+
+set::set(set &&other) noexcept
+{
+    new(get_set()) items_type{std::move(*other.get_set())};
+}
+
+set& set::operator=(const set &other) noexcept
+{
+    *get_set() = *other.get_set();
+    return *this;
+}
+
+set& set::operator=(set &&other) noexcept
+{
+    *get_set() = std::move(*other.get_set());
+    return *this;
+}
+
+set::~set() noexcept
+{
+    get_set()->~set();
+}
+
+[[nodiscard]]
+std::size_t set::size() const noexcept
+{
+    return std::size(get());
+}
+
+[[nodiscard]]
+auto set::get() const noexcept -> items_type const&
+{
+    return *get_set();
+}
+
+struct push::items_type: std::vector<array::item_type>
+{};
+
+push::push(std::istream &stream)
+{
+    new(get_items()) items_type{};
+
+    auto& items_ = *get_items();
+
+    std::string string;
+    std::getline(stream, string);
+    auto count = std::stoll(string);
+    if (count < 1)
+        return;
+    items_.reserve(static_cast<typename items_type::size_type>(count));
+    while (count--)
+    {
+        items_.emplace_back(parse_item(stream));
+    }
+}
+
+push::push(const push &other) noexcept
+{
+    new(get_items()) items_type{*other.get_items()};
+}
+
+push::push(push &&other) noexcept
+{
+    new(get_items()) items_type{std::move(*other.get_items())};
+}
+
+push& push::operator=(const push &other) noexcept
+{
+    *get_items() = *other.get_items();
+    return *this;
+}
+
+push& push::operator=(push &&other) noexcept
+{
+    *get_items() = std::move(*other.get_items());
+    return *this;
+}
+
+push::~push() noexcept
+{
+    get_items()->~vector();
+}
+
+[[nodiscard]]
+std::size_t push::size() const noexcept
+{
+    return std::size(get());
+}
+
+[[nodiscard]]
+auto push::get() const noexcept -> items_type const&
+{
+    return *get_items();
+}
 
 }   // namespace deserialization
 }   // namespace resp

--- a/include/redis-cpp/resp/detail/marker.h
+++ b/include/redis-cpp/resp/detail/marker.h
@@ -25,6 +25,17 @@ constexpr auto error_message = '-';
 constexpr auto integer = ':';
 constexpr auto bulk_string = '$';
 constexpr auto array = '*';
+constexpr auto null = '_';
+constexpr auto boolean = '#';
+constexpr auto double_float = ',';
+constexpr auto big_number = '(';
+constexpr auto bulk_error = '!';
+constexpr auto verbatim_string = '=';
+constexpr auto map = '%';
+constexpr auto attributes = '|';
+constexpr auto attributes_alt = '`';
+constexpr auto set = '~';
+constexpr auto push = '>';
 
 constexpr auto cr = '\r';
 constexpr auto lf = '\n';

--- a/include/redis-cpp/resp/detail/value_ptr.h
+++ b/include/redis-cpp/resp/detail/value_ptr.h
@@ -1,0 +1,66 @@
+#ifndef REDISCPP_RESP_DETAIL_VALUE_PTR_H_
+#define REDISCPP_RESP_DETAIL_VALUE_PTR_H_
+
+#include <memory>
+
+namespace rediscpp
+{
+inline namespace resp
+{
+namespace detail
+{
+template<class T, class D = std::default_delete<T>, class = std::enable_if_t<!std::is_array_v<T> && !std::is_polymorphic_v<T>>>
+class value_ptr: public std::unique_ptr<T, D>
+{
+    using parent_t = std::unique_ptr<T, D>;
+public:
+    template<class... Args, class = std::enable_if_t<std::is_constructible_v<parent_t, Args...>>>
+    value_ptr(Args&&... args)
+        : parent_t(std::forward<Args>(args)...)
+    {}
+    
+    value_ptr(const value_ptr& other)
+        : parent_t(other ? std::make_unique<T>(*other) : nullptr)
+    {}
+    value_ptr& operator=(const value_ptr& other)
+    {
+        if(other)
+        {
+            if(!*this)
+            {
+                parent_t::operator=(std::make_unique<T>(*other));
+            }
+            else
+            {
+                **this = *other;
+            }
+        }
+        else
+        {
+            parent_t::reset();
+        }
+        return *this;
+    }
+    value_ptr& operator=(value_ptr&& other)
+    {
+        parent_t::operator=(std::move(other));
+        return *this;
+    }
+    value_ptr& operator=(std::nullptr_t)
+    {
+        parent_t::operator=(nullptr);
+        return *this;
+    }
+};
+
+template<class T, class... Args>
+value_ptr<T> make_value_ptr(Args&& ...args)
+{
+    return std::make_unique<T>(std::forward<Args>(args)...);
+}
+
+}   // namespace detail
+}   // namespace resp
+}   // namespace rediscpp
+
+#endif  // !REDISCPP_RESP_DETAIL_VALUE_PTR_H_


### PR DESCRIPTION
I'm actively working on a RESP 3 implementation for fun and figured I'd share it for comment before I get too deep into it. I am trying to maintain an interface as close as possible to your RESP 2 implementation, although I've had to make a few compromises to make the recursiveness work without use of boost::variant (although from what I've read, boost variant would have involved more heap allocations than is strictly necessary).

I had a couple specific concerns I want to bring up:
* I went with the first idea I had for creating the map/attributes, set, and push implementations: a buffer managed entirely within the methods, with those methods defined after the declaration of array. I checked using compiler explorer that `sizeof(std::map<...>)` etc doesn't change based on the data type, but it still feels a bit hacky to do this. Are there any better ideas that don't involve an extra heap allocation? Or do you think that extra heap allocation is fine?
* I tend to struggle a bit with organizing my Metaprogramming tools and external, but still header, method definitions; if you have any suggestions here that would be greatly appreciated.
* I hand rolled a copyable pointer to minimize the impact of having to support the fact attributes can be on literally any element. I couldn't find any but are there any value_ptr like objects I could grab from boost (sense its already a dependency) so it doesn't have to be maintained by this repo?
* I am somewhat unsatisfied with the name I went with for the double: `double_float` if you have better suggestions I am 100% willing to consider them.
* I noticed while testing that the attributes marker is actually described to be `` ` `` and `|` on the RESP documentation page at different locations, and I can't seem to do a full search of the redis interface documentation to find a message that is responded to with data that has attributes, do you know a way I might be able to confirm which is actually used?
* When I was writing the `get_marker` functions I did not realize how close it was in name to `get_mark`. But I can't quite think of a name that is sufficiently different.

I am not quite ready to call this ready for merge, I'd like to add resp3 to serialization side and get some tests written for both. But any and all comments would be appreciated.